### PR TITLE
fix(chat): ensure isArchived defaults to false when undefined

### DIFF
--- a/app/(main-pages)/chat/layout.tsx
+++ b/app/(main-pages)/chat/layout.tsx
@@ -96,7 +96,7 @@ export default function ChatLayout({
         : '';
 
       // Check if conversation is archived by this user
-      const isArchived = conversation.archivedByUsers?.includes(user._id);
+      const isArchived = conversation.archivedByUsers?.includes(user._id) ?? false;
 
       // Get unread count for current user
       const userUnreadCount =

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -217,26 +217,6 @@ http.route({
   }),
 });
 
-// Debug endpoint to check environment variables
-http.route({
-  path: '/paystack/debug',
-  method: 'GET',
-  handler: httpAction(async (_, request) => {
-    const origin = request.headers.get('Origin');
-    
-    return new Response(
-      JSON.stringify({
-        hasPaystackKey: !!process.env.PAYSTACK_SECRET_KEY,
-        keyLength: process.env.PAYSTACK_SECRET_KEY?.length || 0,
-        keyPrefix: process.env.PAYSTACK_SECRET_KEY?.substring(0, 10) || 'N/A',
-      }),
-      {
-        status: 200,
-        headers: getJsonHeaders(origin),
-      }
-    );
-  }),
-});
 
 http.route({
   path: '/paystack/verify',


### PR DESCRIPTION
- Updated the isArchived variable to default to false if conversation.archivedByUsers is undefined, improving reliability in chat layout logic.
- Removed the debug endpoint for Paystack key configuration to streamline the codebase and enhance security.