### PR TITLE
fix(chat): ensure archived status defaults to false for conversations

### DIFF
--- a/app/(main-pages)/chat/page.tsx
+++ b/app/(main-pages)/chat/page.tsx
@@ -237,7 +237,10 @@ export default function ChatPage() {
         <ChatSidebar
           activeChat={null}
           activeFilter={activeFilter}
-          conversations={filteredConversations}
+          conversations={filteredConversations.map(convo => ({
+            ...convo,
+            archived: convo.archived ?? false
+          }))}
           searchQuery={searchQuery}
           setActiveChat={() => {}}
           setActiveFilter={setActiveFilter}


### PR DESCRIPTION
- Updated the conversations mapping to set archived status to false if undefined, enhancing data consistency in the chat sidebar.